### PR TITLE
Feature/modify pool list2

### DIFF
--- a/components/list/PoolTableRow.tsx
+++ b/components/list/PoolTableRow.tsx
@@ -287,7 +287,7 @@ const PoolTableRow = ({ poolData }: { poolData: PoolConfig }) => {
               </HoverIcon>
               <HoverIcon isBase={false} hoverText={allCollateralSymbols}>
                 <Row
-                  mainAxisAlignment="flex-start"
+                  mainAxisAlignment="center"
                   crossAxisAlignment="center"
                   overflow="scroll"
                 >


### PR DESCRIPTION
プール一覧の担保資産のアイコンを左寄せから中央揃えに変更いたしました！