### PR TITLE
Feature/modify zindex

### DIFF
--- a/components/pool/StatusBar.tsx
+++ b/components/pool/StatusBar.tsx
@@ -64,11 +64,11 @@ const OverlayValue = styled.div<{
 }>`
   position: absolute;
   bottom: 3px;
-  left: ${({ width }) => GetOverlayValuePosition(width)}%;
+  left: ${({ width }) => GetOverlayValuePosition(width)};
   color: rgba(255, 255, 255, 1);
   font-size: 12px;
   font-weight: bold;
-  z-index: 3;
+  z-index: 1;
 `;
 
 const StatusBar: React.FC<StatusBarProps> = ({ leeway, warning, overlay }) => {


### PR DESCRIPTION
issue #29 位置を固定しているヘッダーにステータスバーの借入率の表示が被ってしまうのを修正する
を修正しました！
ヘッダーに％の表示が被らなくなりました！