### PR TITLE
issue #29 

### DIFF
--- a/components/pool/StatusBar.tsx
+++ b/components/pool/StatusBar.tsx
@@ -64,11 +64,11 @@ const OverlayValue = styled.div<{
 }>`
   position: absolute;
   bottom: 3px;
-  left: ${({ width }) => GetOverlayValuePosition(width)}%;
+  left: ${({ width }) => GetOverlayValuePosition(width)};
   color: rgba(255, 255, 255, 1);
   font-size: 12px;
   font-weight: bold;
-  z-index: 3;
+  z-index: 1;
 `;
 
 const StatusBar: React.FC<StatusBarProps> = ({ leeway, warning, overlay }) => {

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -28,7 +28,7 @@
   "Keep this bar from filling up to avoid being liquidated!": "このバーが一杯になると清算されますので注意して下さい",
   "Limit": "清算限度",
   "Liquidation": "清算",
-  "Liquidation Factor": "清算閾値",
+  "Liquidation Factor": "清算掛目",
   "Liquidation Limit": "清算限度",
   "Liquidation Penalty": "清算ペナルティー",
   "MAX": "MAX",


### PR DESCRIPTION
issue #29 位置を固定しているヘッダーにステータスバーの借入率の表示が被ってしまうのを修正する
に関しまして、devブランチで確認いたしました！
問題なかったので、メインにマージさせて頂きます！